### PR TITLE
Handle conflict error when overwriting immutable tags

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -853,6 +853,10 @@ func (app *App) authorized(w http.ResponseWriter, r *http.Request, context *Cont
 			if err := errcode.ServeJSON(w, errcode.ErrorCodeUnauthorized.WithDetail(accessRecords)); err != nil {
 				dcontext.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
 			}
+		case errcode.Error:
+			if err := errcode.ServeJSON(w, err); err != nil {
+				dcontext.GetLogger(context).Errorf("error serving error json: %v (from %v)", err, context.Errors)
+			}
 		default:
 			// This condition is a potential security problem either in
 			// the configuration or whatever is backing the access

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -383,7 +383,13 @@ func (imh *manifestHandler) PutManifest(w http.ResponseWriter, r *http.Request) 
 		tags := imh.Repository.Tags(imh)
 		err = tags.Tag(imh, imh.Tag, desc)
 		if err != nil {
-			imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+			switch err := err.(type) {
+			case errcode.Error:
+				imh.Errors = append(imh.Errors, err)
+			default:
+				imh.Errors = append(imh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+			}
+
 			return
 		}
 


### PR DESCRIPTION
This adds the ability for the registry to add tag validation, making the tags immutable, and to surface an adequate message back to the user should they try to overwrite an immutable tag.

This was attempted previously in [this PR](https://github.com/distribution/distribution/pull/2587) but was closed and supposed to be reworked into master but never did.

Signed-off-by: Nikhil Banerjee <nikhil.banerjee@unity3d.com>